### PR TITLE
Initialize ChromeClient timeout with default Capybara timeout

### DIFF
--- a/lib/capybara/apparition/driver.rb
+++ b/lib/capybara/apparition/driver.rb
@@ -66,7 +66,7 @@ module Capybara::Apparition
       @client ||= begin
         @launcher ||= Browser::Launcher.start(options)
         ws_url = @launcher.ws_url
-        ::Capybara::Apparition::ChromeClient.client(ws_url.to_s)
+        ::Capybara::Apparition::ChromeClient.client(ws_url.to_s).tap { |client| client.timeout = session_wait_time }
       end
     end
 


### PR DESCRIPTION
## Context
On visiting a URL (`session.visit("https://shopify.com")`) that is executing a long running  synchronous JavaScript,  the driver hangs and never times out.

## Issue
Basically, it ends up calling `ChromeClient.send_cmd_to_session` that is then waiting for the `Page.load` event to complete and given `@timeout` being always `nil`, it waits infinitely.  I _think_ that reusing the already set driver timeout configuration 
make sense instead of having to manually call `session.driver.timeout`.

```
  @msg_mutex.synchronize do
    start_time = Time.now
    while (response = @responses.delete(msg_id)).nil? do
      raise TimeoutError if @timeout && ((Time.now - start_time) > @timeout)
      @message_available.wait(@msg_mutex, 0.1)
    end
  end
```

This [PR](https://github.com/twalpole/apparition/commit/63a7b6830e1168107616ae29ef96c2de9ecfc645) introduced the `@timeout` but couldn't find anything interesting. It's hard to tell if there's any specific reason that wasn't done - I feel like I might have missed something 🤔  