### PR TITLE
Troubleshoot flaky test

### DIFF
--- a/lib/capybara/apparition/browser/launcher/local.rb
+++ b/lib/capybara/apparition/browser/launcher/local.rb
@@ -56,7 +56,7 @@ module Capybara::Apparition
           @pid = wait_thr.pid
 
           @out_thread = Thread.new do
-            while !@stdout_stderr.eof? && (data = @stdout_stderr.readpartial(512))
+            while !@stdout_stderr.eof? && (data = @stdout_stderr.gets)
               @output << data
             end
           end

--- a/lib/capybara/apparition/driver/chrome_client.rb
+++ b/lib/capybara/apparition/driver/chrome_client.rb
@@ -3,6 +3,8 @@
 require 'capybara/apparition/errors'
 require 'capybara/apparition/driver/web_socket_client'
 require 'capybara/apparition/driver/response'
+require 'net/http'
+require 'uri'
 
 module Capybara::Apparition
   class ChromeClient


### PR DESCRIPTION
## Issue
The Chrome WS url is intermittently set to an invalid value.

## Fix
In some cases, Chrome stdout differs in size and cause the Websock URL to be splitted as it is reading 512 byte chunks at a time. This PR is changing the reading logic to be line by line.